### PR TITLE
Configure GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,23 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ work ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - uses: actions/deploy-pages@v1
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Health Quest Website
+
+This repository contains a single-page health quest application.
+
+## GitHub Pages
+
+The site can be hosted using [GitHub Pages](https://pages.github.com/).
+
+1. Open the repository **Settings** and go to **Pages**.
+2. Select the `work` branch and the `/` (root) folder as the source.
+3. Save the settings. After a few moments the site will be available at
+   `https://<your-username>.github.io/Health/`.
+
+An optional GitHub Actions workflow (`.github/workflows/pages.yml`) is provided to
+automatically deploy the site whenever you push changes to the `work` branch.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for deploying to GitHub Pages
- document Pages setup in a new README

## Testing
- `npm test` *(fails: could not read package.json)*