### PR TITLE
Add dark mode toggle and data reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
             <option value="ru">Русский</option>
             <option value="en">English</option>
         </select>
+        <button id="theme-toggle" class="small secondary">🌙 Темная тема</button>
         
         <!-- Health Tree Visualization -->
         <div class="health-tree-container">
@@ -77,6 +78,7 @@
             <button onclick="exportData()" class="small secondary">Экспорт данных</button>
             <input type="file" id="import-file" accept=".json" style="display:none" onchange="handleImport(this)">
             <button class="small" onclick="document.getElementById('import-file').click()">Импорт данных</button>
+            <button class="small warning" onclick="resetGame()">Сбросить данные</button>
         </div>
     </aside>
 

--- a/script.js
+++ b/script.js
@@ -95,6 +95,15 @@ document.addEventListener("DOMContentLoaded", function() {
         langSelect.value = lang;
         langSelect.addEventListener("change", (e) => setLanguage(e.target.value));
     }
+
+    const savedTheme = localStorage.getItem("hqTheme") || "light";
+    if (savedTheme === "dark") {
+        document.body.classList.add("dark-mode");
+    }
+    const themeToggle = document.getElementById("theme-toggle");
+    if (themeToggle) {
+        themeToggle.addEventListener("click", toggleTheme);
+    }
 });
     // Initialize game
     function initializeGame() {
@@ -806,4 +815,17 @@ function updateXPDisplay() {
     if (!gameState.startDate) {
         gameState.startDate = new Date().toISOString();
         saveGameState();
+    }
+
+    function toggleTheme() {
+        const dark = document.body.classList.toggle('dark-mode');
+        localStorage.setItem('hqTheme', dark ? 'dark' : 'light');
+    }
+
+    function resetGame() {
+        if (confirm('Вы уверены, что хотите сбросить все данные?')) {
+            localStorage.removeItem('healthQuestState');
+            localStorage.removeItem('hqTheme');
+            location.reload();
+        }
     }

--- a/style.css
+++ b/style.css
@@ -1,12 +1,31 @@
         /* General Styles */
         * { box-sizing: border-box; }
-        body { 
-            font-family: 'Roboto', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
-            margin: 0; 
-            background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
-            color: #34495e; 
-            display: flex; 
-            min-height: 100vh; 
+
+        :root {
+            --bg-start: #f5f7fa;
+            --bg-end: #c3cfe2;
+            --text-color: #34495e;
+            --sidebar-start: #2c3e50;
+            --sidebar-end: #34495e;
+            --card-bg: rgba(52, 73, 94, 0.5);
+        }
+
+        body.dark-mode {
+            --bg-start: #1b262c;
+            --bg-end: #000000;
+            --text-color: #ecf0f1;
+            --sidebar-start: #0f2027;
+            --sidebar-end: #203a43;
+            --card-bg: rgba(255, 255, 255, 0.05);
+        }
+
+        body {
+            font-family: 'Roboto', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            margin: 0;
+            background: linear-gradient(135deg, var(--bg-start) 0%, var(--bg-end) 100%);
+            color: var(--text-color);
+            display: flex;
+            min-height: 100vh;
         }
 
         .menu-toggle {
@@ -20,11 +39,11 @@
         }
 
         /* Sidebar Styles */
-        .sidebar { 
-            width: 350px; 
-            background: linear-gradient(180deg, #2c3e50 0%, #34495e 100%);
-            color: #ecf0f1; 
-            padding: 25px; 
+        .sidebar {
+            width: 350px;
+            background: linear-gradient(180deg, var(--sidebar-start) 0%, var(--sidebar-end) 100%);
+            color: #ecf0f1;
+            padding: 25px;
             box-shadow: 3px 0 15px rgba(0,0,0,0.2); 
             display: flex; 
             flex-direction: column; 
@@ -49,7 +68,7 @@
         
         /* Health Tree Visualization */
         .health-tree-container {
-            background: rgba(52, 73, 94, 0.5);
+            background: var(--card-bg);
             border-radius: 10px;
             padding: 20px;
             margin-bottom: 20px;
@@ -86,10 +105,10 @@
         }
         
         /* User Stats */
-        .sidebar .user-stats { 
-            margin-bottom: 20px; 
-            padding: 20px; 
-            background: rgba(52, 73, 94, 0.5);
+        .sidebar .user-stats {
+            margin-bottom: 20px;
+            padding: 20px;
+            background: var(--card-bg);
             border-radius: 10px;
             backdrop-filter: blur(10px);
         }
@@ -144,13 +163,13 @@
         }
         
         /* Quote of the Day */
-        .sidebar .quote-of-the-day { 
-            font-size: 0.9em; 
-            font-style: italic; 
-            color: #bdc3c7; 
-            margin-top: 20px; 
+        .sidebar .quote-of-the-day {
+            font-size: 0.9em;
+            font-style: italic;
+            color: #bdc3c7;
+            margin-top: 20px;
             padding: 15px;
-            background: rgba(52, 73, 94, 0.3);
+            background: var(--card-bg);
             border-radius: 8px;
             text-align: center;
             line-height: 1.4;
@@ -758,7 +777,12 @@
             background: linear-gradient(135deg, #d4efdf 0%, #abebc6 100%);
             border-color: #27ae60;
         }
-        
+
+        /* Dark mode specific tweaks */
+        body.dark-mode .sidebar .xp-bar-container {
+            background: rgba(255, 255, 255, 0.2);
+        }
+
         /* Responsive Design */
         @media (max-width: 768px) {
             .menu-toggle {


### PR DESCRIPTION
## Summary
- add dark mode CSS variables and styling tweaks
- allow toggling theme with a new button
- remember chosen theme in local storage
- add data reset option alongside export/import

## Testing
- `npm test` *(fails: ENOENT because package.json is missing)*